### PR TITLE
fix: key provided to wrong element

### DIFF
--- a/src/lib/quartz/quartz.tsx
+++ b/src/lib/quartz/quartz.tsx
@@ -106,9 +106,8 @@ export const ReQuartzCron = ({
     const tabKey = tab.toLowerCase() as keyof typeof tabsLocalization;
 
     return (
-      <li className={genClassName(cssClassPrefix, ['nav-item'], ['c-tab-item'])}>
+      <li key={tab} className={genClassName(cssClassPrefix, ['nav-item'], ['c-tab-item'])}>
         <button
-          key={tab}
           role="tab"
           type="button"
           className={className}


### PR DESCRIPTION
The `key` prop should be provided to the top element created by genTab, or React will throw an error:

![image](https://github.com/ua-cron/react/assets/28727932/f02c6216-0b1b-4a9c-89c1-5f3d3097b2c5)
